### PR TITLE
Workaround TypeScript resolution bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes [#19](https://github.com/compulim/use-ref-from/issues/19). Updated `exports` field to workaround [TypeScript resolution bug](https://github.com/microsoft/TypeScript/issues/50762), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/use-ref-from/pull/20)
+
 ## [0.0.2] - 2023-03-21
 
 ### Fixed

--- a/packages/use-ref-from/package.json
+++ b/packages/use-ref-from/package.json
@@ -3,28 +3,38 @@
   "version": "0.0.0-0",
   "description": "React.useRef with an immediate setter and read-only value.",
   "files": [
-    "./lib/*"
+    "./lib/"
   ],
   "exports": {
     ".": {
-      "import": "./lib/esmodules/index.js",
-      "require": "./lib/commonjs/index.js",
-      "types": "./lib/types/index.d.ts"
+      "import": {
+        "types": "./lib/esmodules-types/index.d.ts",
+        "default": "./lib/esmodules/index.js"
+      },
+      "require": {
+        "types": "./lib/commonjs-types/index.d.ts",
+        "default": "./lib/commonjs/index.js"
+      }
     },
     "./useRefFrom": {
-      "import": "./lib/esmodules/useRefFrom.js",
-      "require": "./lib/commonjs/useRefFrom.js",
-      "types": "./lib/types/useRefFrom.d.ts"
+      "import": {
+        "types": "./lib/esmodules-types/useRefFrom.d.ts",
+        "default": "./lib/esmodules/useRefFrom.js"
+      },
+      "require": {
+        "types": "./lib/commonjs-types/useRefFrom.d.ts",
+        "default": "./lib/commonjs/useRefFrom.js"
+      }
     }
   },
   "main": "./lib/commonjs/index.js",
-  "typings": "./lib/types/index.d.ts",
+  "typings": "./lib/commonjs-types/index.d.ts",
   "scripts": {
-    "build": "npm run build:babel && npm run build:typescript",
-    "build:babel": "npm run build:babel:commonjs && npm run build:babel:esmodules",
+    "build": "npm run build:babel:commonjs && npm run build:babel:esmodules && npm run build:typescript:commonjs && npm run build:typescript:esmodules",
     "build:babel:commonjs": "babel src --config-file ./babel.commonjs.config.json --extensions .ts,.tsx --out-dir ./lib/commonjs/",
     "build:babel:esmodules": "babel src --config-file ./babel.esmodules.config.json --extensions .ts,.tsx --out-dir ./lib/esmodules/",
-    "build:typescript": "tsc --project ./src/tsconfig.declaration.json",
+    "build:typescript:commonjs": "tsc --project ./src/tsconfig.declaration.commonjs.json",
+    "build:typescript:esmodules": "tsc --project ./src/tsconfig.declaration.esmodules.json",
     "bump": "npm run bump:prod && npm run bump:dev && npm run bump:auditfix && npm run bump:babel",
     "bump:auditfix": "npm audit fix || exit 0",
     "bump:babel": "npm run bump:babel:commonjs && npm run bump:babel:esmodules",
@@ -34,7 +44,9 @@
     "bump:prod": "if [ `cat package.json | jq -r '(.dependencies // {}) | length'` -ne 0 ]; then npm install --save-exact $(cat package.json | jq -r '(.pinDependencies // {}) as $p | ((.dependencies // {}) | keys) | map(. + \"@\" + ($p[.] // [\"latest\"])[0]) | .[]'); fi",
     "postbump": "cat package.json | jq '. + (.dependencies = (((.dependencies // {}) + (.localPeerDependencies // {})) | to_entries | sort_by(.key) | from_entries)) | (.devDependencies = (((.devDependencies // {}) + (.localPeerDevDependencies // {})) | to_entries | sort_by(.key) | from_entries))' > package-temp.json && mv package-temp.json package.json",
     "prebump": "cat package.json | jq '(((.localPeerDependencies // {}) | keys | map([\"dependencies\", .])) + ((.localPeerDevDependencies // {}) | keys | map([\"devDependencies\", .]))) as $localPeerPaths | delpaths($localPeerPaths)' > package-temp.json && mv package-temp.json package.json",
-    "precommit": "eslint ./src/",
+    "precommit": "npm run precommit:eslint && npm run precommit:typescript",
+    "precommit:eslint": "eslint ./src/",
+    "precommit:typescript": "tsc --noEmit --project ./src/tsconfig.json",
     "prepack": "cp ../../CHANGELOG.md . && cp ../../LICENSE . && cp ../../README.md .",
     "test": "jest"
   },

--- a/packages/use-ref-from/src/tsconfig.declaration.commonjs.json
+++ b/packages/use-ref-from/src/tsconfig.declaration.commonjs.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "declarationDir": "../lib/commonjs-types/",
+    "module": "CommonJS"
+  },
+  "extends": "./tsconfig.declaration.json"
+}

--- a/packages/use-ref-from/src/tsconfig.declaration.esmodules.json
+++ b/packages/use-ref-from/src/tsconfig.declaration.esmodules.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "declarationDir": "../lib/esmodules-types/",
+    "module": "ESNext"
+  },
+  "extends": "./tsconfig.declaration.json"
+}

--- a/packages/use-ref-from/src/tsconfig.declaration.json
+++ b/packages/use-ref-from/src/tsconfig.declaration.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "declarationDir": "../lib/types/",
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "moduleResolution": "NodeNext"
   },
   "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixes [#19](https://github.com/compulim/use-ref-from/issues/19). Updated `exports` field to workaround [TypeScript resolution bug](https://github.com/microsoft/TypeScript/issues/50762), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/use-ref-from/pull/20)

## Specific changes

> Please list each individual specific change in this pull request.

- Build typings of CommonJS and ES Modules separately
- Updated `package.json/exports` to export typings of CommonJS and ES Modules separately
- Updated `package.json/files` to pack files under `./lib/` correctly
- Added `precommit:typescript` to do type-checking after ESLint