### PR TITLE
Use @tsconfig/strictest for pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added type-checking for test, by [@compulim](https://github.com/compulim), in PR [#22](https://github.com/compulim/use-ref-from/pull/22)
-- Updates `tsconfig.json` to extend from [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest), by [@compulim](https://github.com/compulim), in PR [#21](https://github.com/compulim/use-ref-from/pull/21)
+- Updates `tsconfig.json` to extend from [`@tsconfig/strictest`](https://npmjs.com/package/@tsconfig/strictest), by [@compulim](https://github.com/compulim), in PR [#21](https://github.com/compulim/use-ref-from/pull/21) and PR [#23](https://github.com/compulim/use-ref-from/pull/23)
    - Development dependencies
       - [`@types/react@18.2.21`](https://npmjs.com/package/@types/react)
       - [`@types/react-dom@18.2.7`](https://npmjs.com/package/@types/react-dom)

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -18,6 +18,7 @@
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
   "devDependencies": {
+    "@tsconfig/strictest": "^2.0.2",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "esbuild": "^0.19.2",

--- a/packages/pages/src/tsconfig.json
+++ b/packages/pages/src/tsconfig.json
@@ -7,5 +7,6 @@
     "noEmit": true,
     "strict": true,
     "target": "ESNext"
-  }
+  },
+  "extends": "@tsconfig/strictest/tsconfig.json"
 }

--- a/packages/use-ref-from/babel.jest.config.json
+++ b/packages/use-ref-from/babel.jest.config.json
@@ -1,13 +1,4 @@
 {
-  "plugins": [
-    [
-      "@babel/plugin-transform-runtime",
-      {
-        "corejs": 3,
-        "version": "7.21.0"
-      }
-    ]
-  ],
   "presets": [
     "@babel/preset-typescript",
     [

--- a/packages/use-ref-from/src/tsconfig.precommit.production.json
+++ b/packages/use-ref-from/src/tsconfig.precommit.production.json
@@ -7,6 +7,6 @@
     "noEmit": true,
     "strict": true
   },
-  "exclude": ["**/*.spec.ts", "**/*.test.ts", "__test__/**/*"],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "__tests__/**/*"],
   "extends": "@tsconfig/strictest/tsconfig.json"
 }

--- a/packages/use-ref-from/src/tsconfig.precommit.test.json
+++ b/packages/use-ref-from/src/tsconfig.precommit.test.json
@@ -8,5 +8,5 @@
     "strict": true
   },
   "extends": "@tsconfig/recommended/tsconfig.json",
-  "include": ["**/*.spec.ts", "**/*.test.ts", "__test__/**/*"]
+  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "__tests__/**/*"]
 }


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Fixes [#19](https://github.com/compulim/use-ref-from/issues/19). Updated `exports` field to workaround [TypeScript resolution bug](https://github.com/microsoft/TypeScript/issues/50762), by [@compulim](https://github.com/compulim), in PR [#20](https://github.com/compulim/use-ref-from/pull/20)

## Specific changes

> Please list each individual specific change in this pull request.

- Use `@tsconfig/strictest` in `packages/pages`