### PR TITLE
Relax peerDependencies to react@16.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/compulim/use-ref-from/pull/XX)
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#47](https://github.com/compulim/use-ref-from/pull/47)
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#43](https://github.com/compulim/use-ref-from/pull/43) and [#45](https://github.com/compulim/use-ref-from/pull/45)
    - Production dependencies
       - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/compulim/use-ref-from/pull/XX)
 - Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#43](https://github.com/compulim/use-ref-from/pull/43) and [#45](https://github.com/compulim/use-ref-from/pull/45)
    - Production dependencies
       - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "use-ref-from-root",
-  "version": "0.0.4-0",
+  "version": "0.1.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "use-ref-from-root",
-      "version": "0.0.4-0",
+      "version": "0.1.0-0",
       "license": "MIT",
       "workspaces": [
         "packages/use-ref-from",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-ref-from-root",
-  "version": "0.0.4-0",
+  "version": "0.1.0-0",
   "description": "",
   "private": true,
   "author": "William Wong (https://github.com/compulim)",

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -14,6 +14,29 @@
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
+  "switch:react:16": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@types/react": "^16",
+      "react": "16.8.0",
+      "react-test-renderer": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@types/react": "^17",
+      "react": "17.0.0",
+      "react-test-renderer": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "react": "18.0.0",
+      "react-test-renderer": "18.0.0"
+    }
+  },
   "localPeerDependencies": {
     "use-ref-from": "^0.0.0-0"
   },

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -16,6 +16,36 @@
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
+  "switch:react:16": {
+    "devDependencies": {
+      "@types/react": "^16",
+      "@types/react-dom": "^16"
+    },
+    "dependencies": {
+      "react": "16.8.0",
+      "react-dom": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@types/react": "^17",
+      "@types/react-dom": "^17"
+    },
+    "dependencies": {
+      "react": "17.0.0",
+      "react-dom": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "@types/react-dom": "^18"
+    },
+    "dependencies": {
+      "react": "18.0.0",
+      "react-dom": "18.0.0"
+    }
+  },
   "localPeerDependencies": {
     "use-ref-from": "^0.0.0-0"
   },

--- a/packages/use-ref-from/package.json
+++ b/packages/use-ref-from/package.json
@@ -66,8 +66,31 @@
     "url": "https://github.com/compulim/use-ref-from/issues"
   },
   "homepage": "https://github.com/compulim/use-ref-from#readme",
+  "switch:react:16": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@types/react": "^16",
+      "react": "16.8.0",
+      "react-test-renderer": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@types/react": "^17",
+      "react": "17.0.0",
+      "react-test-renderer": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "react": "18.0.0",
+      "react-test-renderer": "18.0.0"
+    }
+  },
   "peerDependencies": {
-    "react": ">=16.9.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.1",

--- a/packages/use-ref-from/package.json
+++ b/packages/use-ref-from/package.json
@@ -69,6 +69,7 @@
   "switch:react:16": {
     "devDependencies": {
       "@testing-library/react": "^12",
+      "@testing-library/react-hooks": "latest",
       "@types/react": "^16",
       "react": "16.8.0",
       "react-test-renderer": "16.8.0"
@@ -77,6 +78,7 @@
   "switch:react:17": {
     "devDependencies": {
       "@testing-library/react": "^12",
+      "@testing-library/react-hooks": "latest",
       "@types/react": "^17",
       "react": "17.0.0",
       "react-test-renderer": "17.0.0"

--- a/packages/use-ref-from/src/useRefFrom.spec.ts
+++ b/packages/use-ref-from/src/useRefFrom.spec.ts
@@ -1,8 +1,14 @@
 /** @jest-environment jsdom */
 
-import { renderHook } from '@testing-library/react';
+import type { renderHook as RenderHookType } from '@testing-library/react';
 import { useCallback } from 'react';
 import useRefFrom from './useRefFrom';
+
+const renderHook: typeof RenderHookType =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('should get initial value', () => {
   // WHEN: Calling useRefFrom() with 123.

--- a/packages/use-ref-from/src/useRefFrom.spec.ts
+++ b/packages/use-ref-from/src/useRefFrom.spec.ts
@@ -1,10 +1,13 @@
 /** @jest-environment jsdom */
 
-import type { renderHook as RenderHookType } from '@testing-library/react';
 import { useCallback } from 'react';
 import useRefFrom from './useRefFrom';
 
-const renderHook: typeof RenderHookType =
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderHook: <T, P>(
+  render: (props: P) => T,
+  options?: { initialProps: P }
+) => { rerender: (props: P) => void; result: { current: T } } =
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   require('@testing-library/react').renderHook ||
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/use-ref-from/src/useRefFrom.spec.ts
+++ b/packages/use-ref-from/src/useRefFrom.spec.ts
@@ -3,7 +3,6 @@
 import { useCallback } from 'react';
 import useRefFrom from './useRefFrom';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const renderHook: <T, P>(
   render: (props: P) => T,
   options?: { initialProps: P }


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#47](https://github.com/compulim/use-ref-from/pull/47)

## Specific changes

> Please list each individual specific change in this pull request.

- Run `npm version --no-git-tag-version preminor` to bump to `0.1.0-0`
- Update `/packages/use-ref-from/package.json/peerDependencies/react` to `>=16.8.0`
- Add `package.json/switch:react:*` to target multiple React versions